### PR TITLE
fix: ensure ReceiverSupervisor does not restart Receiver when one dies

### DIFF
--- a/lib/socket_proxy/receiver.ex
+++ b/lib/socket_proxy/receiver.ex
@@ -1,5 +1,5 @@
 defmodule SocketProxy.Receiver do
-  use GenServer, restart: :temporary
+  use GenServer
   require Logger
 
   def start_link(args) do

--- a/lib/socket_proxy/receiver_supervisor.ex
+++ b/lib/socket_proxy/receiver_supervisor.ex
@@ -7,16 +7,12 @@ defmodule SocketProxy.ReceiverSupervisor do
   end
 
   def start_child(arg) do
-    spec = %{id: SocketProxy.Receiver, start: {SocketProxy.Receiver, :start_link, [arg]}}
+    spec = %{id: SocketProxy.Receiver, start: {SocketProxy.Receiver, :start_link, [arg]}, restart: :temporary}
     {:ok, _pid} = DynamicSupervisor.start_child(__MODULE__, spec)
   end
 
   @impl DynamicSupervisor
   def init(_arg) do
     DynamicSupervisor.init(strategy: :one_for_one)
-  end
-
-  def receiver_child_spec do
-    Supervisor.child_spec(SocketProxy.Receiver, start: {SocketProxy.Receiver, :start_link, []})
   end
 end

--- a/test/socket_proxy_test.exs
+++ b/test/socket_proxy_test.exs
@@ -7,15 +7,20 @@ defmodule SocketProxyTest do
     {:ok, src2} = GenServer.start_link(FakeSource, 8080)
     {:ok, dest1} = GenServer.start_link(FakeDestination, 8081)
     {:ok, dest2} = GenServer.start_link(FakeDestination, 8082)
-
     # Start up socket proxy
     port = 8080
     destinations = [{'127.0.0.1', 8081}, {'localhost', 8082}]
     Application.put_env(:socket_proxy, :listen_port, port)
     Application.put_env(:socket_proxy, :destinations, destinations)
     {:ok, _pid} = start_supervised({SocketProxy, {port, destinations}})
-    {:ok, _pid} = start_supervised(SocketProxy.ReceiverSupervisor)
+    {:ok, rec_sup_pid} = start_supervised(SocketProxy.ReceiverSupervisor)
     :timer.sleep(50)
+
+    # ReceiverSupervisor starts child for each created source
+    [
+      {_, rec_pid_1, :worker, [SocketProxy.Receiver]},
+      {_, rec_pid_2, :worker, [SocketProxy.Receiver]}
+    ] = DynamicSupervisor.which_children(rec_sup_pid)
 
     #  Send some messages
     GenServer.call(src1, {:send_message, "src1msg1"})
@@ -29,13 +34,27 @@ defmodule SocketProxyTest do
     assert GenServer.call(dest1, :messages) == "src1msg1src1msg2src2msg1src2msg2"
     assert GenServer.call(dest2, :messages) == "src1msg1src1msg2src2msg1src2msg2"
 
-    # Source dies and new one starts
-    Process.exit(src1, :normal)
+    # Source dies
+    Process.flag :trap_exit, true
+    Process.exit(src1, :shutdown)
+    :timer.sleep(3_500)
+    # ReceiverSupervisor child dies when source dies
+    [
+      {_, new_rec_pid_1, :worker, [SocketProxy.Receiver]},
+    ] = DynamicSupervisor.which_children(rec_sup_pid)
+    assert Enum.member?([rec_pid_1, rec_pid_2], new_rec_pid_1)
+
+    # A new source starts
     {:ok, new_src} = GenServer.start_link(FakeSource, 8080)
 
-    # # New source's messages arrive at destinations
+    # New source's messages arrive at destinations
     GenServer.call(new_src, {:send_message, "newmsg"})
     :timer.sleep(10)
+    # ReceiverSupervisor creates starts new child when new source starts
+    [
+      {_, ^new_rec_pid_1, :worker, [SocketProxy.Receiver]},
+      {_, _, :worker, [SocketProxy.Receiver]}
+    ] = DynamicSupervisor.which_children(rec_sup_pid)
     assert GenServer.call(dest1, :messages) =~ "newmsg"
     assert GenServer.call(dest2, :messages) =~ "newmsg"
 
@@ -75,6 +94,10 @@ defmodule FakeDestination do
 
   def handle_info({:tcp, _port, data}, {lsock, socks, msgs}) do
     {:noreply, {lsock, socks, msgs <> data}}
+  end
+
+  def handle_info({:tcp_closed, _}, state) do
+    {:noreply, state}
   end
 
   def terminate(_reason, {lsock, socks, _msgs}) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏙 investigate: Does socket_proxy try to reconnect too often?](https://app.asana.com/0/584764604969369/1178284533518777/f)

Changes:
* Move `restart: :temporary` from `Receiver` definition to child spec defined within `ReceiverSupervisor` (I think specifying the spec in `ReceiverSupervisor` overrides options specified in the `Receiver` module)
* Remove unused `ReceiverSupervisor.receiver_child_spec/0` function
* Add test assertions

TODO:
- [ ] create separate task to use `ranch` like `rtr`

[Please include a brief description of what was changed]

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] Meets ticket's acceptance criteria
