### PR TITLE
fix: Socket Leak

### DIFF
--- a/lib/socket_proxy/forwarder.ex
+++ b/lib/socket_proxy/forwarder.ex
@@ -19,7 +19,12 @@ defmodule SocketProxy.Forwarder do
            3_000
          ) do
       {:ok, socket} ->
-        Logger.info("SocketProxy.Forwarder connected to socket #{Util.format_socket(socket)}")
+        Logger.info(
+          "SocketProxy.Forwarder connected to socket=#{Util.format_socket(socket)} port=#{
+            inspect(socket)
+          } pid=#{inspect(self())}"
+        )
+
         {:noreply, %{state | socket: socket}}
 
       {:error, _reason} ->
@@ -40,9 +45,9 @@ defmodule SocketProxy.Forwarder do
 
       {:error, reason} ->
         Logger.error(
-          "SocketProxy.Forwarder send/2 error #{inspect(reason)} on #{
+          "SocketProxy.Forwarder send/2 error #{inspect(reason)} on socket=#{
             Util.format_socket(state.socket)
-          }. Reconnecting..."
+          } port=#{inspect(state.socket)} pid=#{inspect(self())}. Reconnecting..."
         )
 
         :gen_tcp.close(state.socket)
@@ -57,7 +62,10 @@ defmodule SocketProxy.Forwarder do
   end
 
   def handle_info({:tcp_closed, _port}, state) do
-    Logger.warn("SocketProxy.Forwarder socket closed. Reconnecting...")
+    Logger.warn(
+      "SocketProxy.Forwarder socket closed. port=#{inspect(state.socket)} pid=#{inspect(self())} Reconnecting..."
+    )
+
     send(self(), :connect)
     {:noreply, %{state | socket: nil}}
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💳 Investigate: why does socket_proxy reconnect so much?](https://app.asana.com/0/281253957434160/1198173672368745)

This fixes an issue where a `Forwarder` could inadvertently be responsible for multiple sockets. See the commit message on the second commit for an explanation of the issue.

I haven't been able to think of a good way to add a failing test case for the race condition 🤔 . Nevertheless, it's been running on opstech3 for the past week without issues (and has minimized the disconnect/reconnect spam).

There is an outstanding issue: I believe it's possible that a given `Forwarder` may have its upstream socket connection go stale. If the OCC reconnects a given socket to `socket_proxy`, it will create a new `Forwarder` to pass the data to AWS. However, in some cases, I think the old `Forwarder` for that socket remains alive, and just doesn't receive any data. In such a scenario, its sockets to AWS will time out periodically and reconnect. I've added logging with the number of `:data` messages received when a socket disconnects in order to diagnose this condition. If it is, in fact, the case, a subsequent PR can add some logic to prune stale `Forwarder` processes.

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] Meets ticket's acceptance criteria
